### PR TITLE
#112: App crashes on saving image without any name after picking folder

### DIFF
--- a/app/src/main/java/dev/arkbuilders/arkretouch/presentation/edit/EditScreen.kt
+++ b/app/src/main/java/dev/arkbuilders/arkretouch/presentation/edit/EditScreen.kt
@@ -76,6 +76,7 @@ import dev.arkbuilders.arkretouch.presentation.theme.Gray
 import dev.arkbuilders.arkretouch.presentation.utils.askWritePermissions
 import dev.arkbuilders.arkretouch.presentation.utils.getActivity
 import dev.arkbuilders.arkretouch.presentation.utils.isWritePermGranted
+import dev.arkbuilders.arkretouch.presentation.utils.toast
 import java.nio.file.Path
 
 @Composable
@@ -364,6 +365,9 @@ private fun BoxScope.TopMenu(
         SavePathDialog(
             initialImagePath = imagePath,
             fragmentManager = fragmentManager,
+            onEmptyFileName = {
+                context.toast(R.string.ark_retouch_file_name_missing)
+            },
             onDismissClick = { viewModel.showSavePathDialog = false },
             onPositiveClick = { savePath ->
                 viewModel.saveImage(savePath)

--- a/app/src/main/java/dev/arkbuilders/arkretouch/presentation/edit/SavePathDialog.kt
+++ b/app/src/main/java/dev/arkbuilders/arkretouch/presentation/edit/SavePathDialog.kt
@@ -52,6 +52,7 @@ import kotlin.streams.toList
 fun SavePathDialog(
     initialImagePath: Path?,
     fragmentManager: FragmentManager,
+    onEmptyFileName: () -> Unit,
     onDismissClick: () -> Unit,
     onPositiveClick: (Path) -> Unit
 ) {
@@ -128,6 +129,10 @@ fun SavePathDialog(
                     value = name,
                     onValueChange = {
                         name = it
+                        if (name.isEmpty()) {
+                            onEmptyFileName()
+                            return@OutlinedTextField
+                        }
                         currentPath?.let { path ->
                             imagePath = path.resolve(name)
                             showOverwriteCheckbox.value = Files.list(path).toList()
@@ -175,7 +180,11 @@ fun SavePathDialog(
                     Button(
                         modifier = Modifier.padding(5.dp),
                         onClick = {
-                            if (currentPath != null && name != null)
+                            if (name.isEmpty()) {
+                                onEmptyFileName()
+                                return@Button
+                            }
+                            if (currentPath != null)
                                 onPositiveClick(currentPath!!.resolve(name))
                         }
                     ) {

--- a/app/src/main/java/dev/arkbuilders/arkretouch/presentation/utils/Utils.kt
+++ b/app/src/main/java/dev/arkbuilders/arkretouch/presentation/utils/Utils.kt
@@ -9,6 +9,8 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.Settings
+import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -97,4 +99,8 @@ fun PointerEvent.calculateRotationFromOneFingerGesture(
         }
     }
     return angleDelta.toFloat()
+}
+
+fun Context.toast(@StringRes stringId: Int) {
+    Toast.makeText(this, getString(stringId), Toast.LENGTH_SHORT).show()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,5 @@
     <string name="height_empty">Please enter height</string>
     <string name="blur_intensity">Intensity</string>
     <string name="blur_size">Size</string>
+    <string name="ark_retouch_file_name_missing">Please provide file name</string>
 </resources>


### PR DESCRIPTION
Solves:
- #112

Now it displays message in case of empty filename:

https://github.com/ARK-Builders/ARK-Retouch/assets/87703131/da126129-af50-4bc8-954e-65c22a2b5195
