### PR TITLE
Smaller image size on blur click crash fixed

### DIFF
--- a/app/src/main/java/dev/arkbuilders/arkretouch/presentation/edit/blur/BlurIntensityPopup.kt
+++ b/app/src/main/java/dev/arkbuilders/arkretouch/presentation/edit/blur/BlurIntensityPopup.kt
@@ -48,7 +48,9 @@ fun BlurIntensityPopup(
                         editManager.blurOperation.blurSize.value = it
                         editManager.blurOperation.resize()
                     },
-                    valueRange = 100f..500f,
+                    valueRange =
+                    editManager.blurOperation.minBlurSize..editManager
+                        .blurOperation.maxBlurSize,
                 )
             }
         }


### PR DESCRIPTION
Before
https://github.com/ARK-Builders/ARK-Retouch/assets/87703131/da5a50d5-c209-4f54-a04d-fb6e0498d02b

After
https://github.com/ARK-Builders/ARK-Retouch/assets/87703131/254de0f7-8405-43e9-a0d1-bbe905602384

